### PR TITLE
前后端对接：初版

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -37,7 +37,7 @@
     <ConfirmationsSetting value="0" id="Add" />
     <ConfirmationsSetting value="0" id="Remove" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" assert-keyword="true" jdk-15="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,12 +10,20 @@ android {
         targetSdkVersion 24
         versionCode 1
         versionName "1.0"
+
+        jackOptions {
+            enabled true
+        }
     }
     buildTypes {
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 
@@ -31,5 +39,9 @@ dependencies {
     compile 'com.squareup.retrofit2:retrofit:2.3.0'
     compile 'com.squareup.okhttp3:logging-interceptor:3.8.0'
     compile 'com.squareup.retrofit2:converter-gson:2.1.0'
+    compile 'com.nostra13.universalimageloader:universal-image-loader:1.9.5'
+    compile 'com.tbruyelle.rxpermissions2:rxpermissions:0.9.4@aar'
+    compile 'io.reactivex.rxjava2:rxandroid:2.0.1'
+    compile "io.reactivex.rxjava2:rxjava:2.1.0"
     testCompile 'junit:junit:4.12'
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,5 +28,8 @@ dependencies {
     compile 'com.android.support:support-v4:24.2.1'
     compile 'io.github.mayubao:pay_library:1.0.1'
     compile 'com.github.limxing:Android-PromptDialog:1.1.1'
+    compile 'com.squareup.retrofit2:retrofit:2.3.0'
+    compile 'com.squareup.okhttp3:logging-interceptor:3.8.0'
+    compile 'com.squareup.retrofit2:converter-gson:2.1.0'
     testCompile 'junit:junit:4.12'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,11 @@
     <uses-permission android:name="android.permission.GET_ACCOUNTS" />
     <uses-permission android:name="android.permission.READ_PROFILE" />
     <uses-permission android:name="android.permission.READ_CONTACTS" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <!-- Include following permission if you load images from Internet -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- Include following permission if you want to cache images on SD card -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:allowBackup="true"
@@ -13,15 +18,8 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity
-            android:name=".Activities.LoginActivity"
-            android:label="@string/app_name">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
 
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
-        </activity>
+        <activity android:name=".Activities.LoginActivity" />
         <activity
             android:name=".Activities.MovieInfoActivity"
             android:label="@string/app_name">
@@ -37,7 +35,14 @@
         </activity>
         <activity android:name=".Activities.CinemaDetail" />
         <activity android:name=".Activities.SelectSeatActivity" />
-        <activity android:name=".Activities.CinemaActivity"></activity>
+        <activity android:name=".Activities.CinemaActivity" />
+        <activity android:name=".Activities.CheckPermissionActivity"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Activities/CheckPermissionActivity.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Activities/CheckPermissionActivity.java
@@ -1,0 +1,70 @@
+package com.x7.ssad.ticketsystem.Activities;
+
+import android.Manifest;
+import android.content.Intent;
+import android.os.Handler;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.widget.Toast;
+
+import com.nostra13.universalimageloader.cache.disc.naming.Md5FileNameGenerator;
+import com.nostra13.universalimageloader.core.DisplayImageOptions;
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
+import com.nostra13.universalimageloader.core.assist.QueueProcessingType;
+import com.tbruyelle.rxpermissions2.RxPermissions;
+import com.x7.ssad.ticketsystem.R;
+
+public class CheckPermissionActivity extends AppCompatActivity {
+
+    Handler mHandler = new Handler();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_check_permission);
+
+        //Configuring Universal Image Loader
+//        ImageLoaderConfiguration config = ImageLoaderConfiguration.createDefault(getApplicationContext());
+        DisplayImageOptions displayImageOptions = new DisplayImageOptions.Builder()
+                .cacheInMemory(true)
+                .cacheOnDisk(true)
+                .build();
+
+        ImageLoaderConfiguration config = new ImageLoaderConfiguration.Builder(getApplicationContext())
+                .defaultDisplayImageOptions(displayImageOptions)
+                .threadPriority(Thread.NORM_PRIORITY - 2)
+                .denyCacheImageMultipleSizesInMemory()
+                .diskCacheFileNameGenerator(new Md5FileNameGenerator())
+                .diskCacheSize(80 * 1024 * 1024)  //80MB for cache
+                .tasksProcessingOrder(QueueProcessingType.LIFO)
+                .writeDebugLogs()
+                .build();
+
+        ImageLoader.getInstance().init(config);
+
+        RxPermissions rxPermissions = new RxPermissions(this);
+        rxPermissions
+                .request(Manifest.permission.ACCESS_COARSE_LOCATION,
+                        Manifest.permission.INTERNET,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                .subscribe(granted -> {
+
+                    if (granted) {
+                        Toast.makeText(CheckPermissionActivity.this, "Granted", Toast.LENGTH_SHORT).show();
+                        Intent i = new Intent(CheckPermissionActivity.this, LoginActivity.class);
+                        startActivity(i);
+                    } else {
+                        Toast.makeText(CheckPermissionActivity.this, "App will close in 3 secs.", Toast.LENGTH_SHORT).show();
+                        mHandler.postDelayed(new Runnable() {
+                            @Override
+                            public void run() {
+                                finish();
+                            }
+                        }, 3000);
+                    }
+
+                });
+
+    }
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Activities/CinemaActivity.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Activities/CinemaActivity.java
@@ -3,6 +3,7 @@ package com.x7.ssad.ticketsystem.Activities;
 import android.content.Intent;
 import android.support.v7.app.AppCompatActivity;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
 import android.widget.ListView;
@@ -38,6 +39,8 @@ public class CinemaActivity extends AppCompatActivity {
 //            c = new Cinema("今日珠江国际影城", "番禺区小谷围贝岗二横路1好店 新天地店", 30);
 //            cinemaList.add(c);
 //        }
+
+        Log.d("Cinema", cinemaList.toString());
 
         CinemaAdapter cinemaAdapter = new CinemaAdapter(cinemaList, CinemaActivity.this);
         cinemaListView.setAdapter(cinemaAdapter);

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Activities/LoginActivity.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Activities/LoginActivity.java
@@ -32,6 +32,8 @@ import android.widget.EditText;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
+import com.nostra13.universalimageloader.core.ImageLoaderConfiguration;
 import com.x7.ssad.ticketsystem.Backend.BackendStub;
 import com.x7.ssad.ticketsystem.Model.User;
 import com.x7.ssad.ticketsystem.R;
@@ -98,6 +100,9 @@ public class LoginActivity extends AppCompatActivity implements LoaderCallbacks<
         mProgressView = findViewById(R.id.login_progress);
 
         SM = SessionManager.getInstance();
+
+
+
     }
 
     private void populateAutoComplete() {

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Adapters/HotOnAirMovieAdapter.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Adapters/HotOnAirMovieAdapter.java
@@ -39,22 +39,19 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
 
     Activity _a;
     Resources res;
-    private BackendStub Backend;
     private List<Movie> movie_list;
     private LayoutInflater mInflater;
 
     SimpleDateFormat ft;
 
-    public HotOnAirMovieAdapter(Activity activity, BackendStub backend) {
+    public HotOnAirMovieAdapter(Activity activity, List<Movie> movies) {
         super();
-        Backend = backend;
         mInflater = LayoutInflater.from(activity);
 
         _a = activity;
         res = activity.getResources();
-        movie_list = Backend.getHotOnAirMovies();
         ft = new SimpleDateFormat("yyyy.MM.dd");
-
+        movie_list = movies;
     }
 
     @Override
@@ -77,7 +74,7 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
 
         final Movie m = movie_list.get(i);
 
-        Log.d("Adpater", m.name);
+//        Log.d("Adpater", m.name);
 
         Button buyNormal;
         Button buyWait;
@@ -87,7 +84,7 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
         int sc = 100, sn = 1000;
         holder.poster.setImageResource(m.imageid);
         holder.movieName.setText(m.name);
-        holder.movieIntro.setText(m.movieIntro);
+        holder.movieIntro.setText(m.oneSentence);
 
         //影片正在上演
         if (movie_list.get(i).onair) {
@@ -141,7 +138,7 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
 
     @Override
     public int getItemCount() {
-        return Backend.getHotOnAirMovies().size();
+        return movie_list.size();
     }
 
     public static class ViewHolder extends RecyclerView.ViewHolder {

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Adapters/HotOnAirMovieAdapter.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Adapters/HotOnAirMovieAdapter.java
@@ -15,6 +15,7 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
+import com.nostra13.universalimageloader.core.ImageLoader;
 import com.x7.ssad.ticketsystem.Activities.MovieInfoActivity;
 import com.x7.ssad.ticketsystem.Backend.BackendStub;
 import com.x7.ssad.ticketsystem.Model.Movie;
@@ -44,6 +45,8 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
 
     SimpleDateFormat ft;
 
+    ImageLoader imageLoader = ImageLoader.getInstance();
+
     public HotOnAirMovieAdapter(Activity activity, List<Movie> movies) {
         super();
         mInflater = LayoutInflater.from(activity);
@@ -52,6 +55,7 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
         res = activity.getResources();
         ft = new SimpleDateFormat("yyyy.MM.dd");
         movie_list = movies;
+
     }
 
     @Override
@@ -82,7 +86,9 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
         //Filling Item
         //TODO: Implement a Cinema Manager Stub
         int sc = 100, sn = 1000;
-        holder.poster.setImageResource(m.imageid);
+        //holder.poster.setImageResource(m.imageid);
+        imageLoader.displayImage(m.mediumImageURI, holder.poster);
+
         holder.movieName.setText(m.name);
         holder.movieIntro.setText(m.oneSentence);
 
@@ -91,7 +97,7 @@ public class HotOnAirMovieAdapter extends RecyclerView.Adapter<HotOnAirMovieAdap
             holder.showingTips.setText(res.getString(R.string.showing_cinema, sc, sn));
 
 
-            if (m.audience_rating != -1) {
+            if (m.audience_rating != 0.0) {
                 holder.ratingText1.setText("观众 ");
                 holder.ratingText2.setText(String.format("%.1f", m.audience_rating));
                 holder.ratingText1.setTextColor(res.getColor(R.color.textColor));

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Backend/BackendStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Backend/BackendStub.java
@@ -4,11 +4,15 @@ import android.util.Log;
 
 import com.x7.ssad.ticketsystem.Cache.CinemaCacheStub;
 import com.x7.ssad.ticketsystem.Cache.MovieCacheStub;
+import com.x7.ssad.ticketsystem.Cache.UserDAOStub;
 import com.x7.ssad.ticketsystem.Model.Cinema;
 import com.x7.ssad.ticketsystem.Model.Movie;
+import com.x7.ssad.ticketsystem.Model.User;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import retrofit2.Retrofit;
 
 /**
  * Created by WangYinghao on 5/26/17.
@@ -16,15 +20,28 @@ import java.util.List;
 
 //TODO: Change this to a real backend communication system.
 public class BackendStub {
+
+
     private static BackendStub ourInstance = new BackendStub();
     List<String> USERS;
     List<String> PASSWORDS;
+
+    UserDAOStub UD;
     CinemaCacheStub CCS;
     MovieCacheStub MCS;
+
+    Retrofit retrofit;
 
     private BackendStub() {
         USERS = new ArrayList<>();
         PASSWORDS = new ArrayList<>();
+
+        UD = new UserDAOStub();
+        CCS = new CinemaCacheStub();
+        MCS = new MovieCacheStub();
+
+        retrofit = new Retrofit.Builder().baseUrl("http://localhost:8081").build();
+
     }
 
     public static BackendStub getInstance() {
@@ -36,9 +53,6 @@ public class BackendStub {
 
         USERS.add(username);
         PASSWORDS.add(password);
-
-        CCS = new CinemaCacheStub();
-        MCS = new MovieCacheStub();
 
         Log.d("Backend Stub", "User Added");
 
@@ -63,6 +77,50 @@ public class BackendStub {
         for (int i = 0; i < USERS.size(); i++) {
             if (username.equals(USERS.get(i))) {
                 if (password.equals(PASSWORDS.get(i))) {
+                    Log.d("Backend Stub", "Log in Successful.");
+                    return true;
+                }
+                else {
+                    Log.d("Backend Stub", "Password Incorrect.");
+                    return false;
+                }
+            }
+        }
+
+        Log.d("Backend Stub", "Unknown Error.");
+        return false;
+
+    }
+
+    //Precondition: Check Duplicate Before Using.
+    public boolean addUser(User u) {
+
+        UD.getUserList().add(u);
+
+        Log.d("Backend Stub", "User Added");
+
+        return true;
+
+    }
+
+    public boolean userExists(User u) {
+
+        for (int i = 0; i < UD.getUserList().size(); i++) {
+            if (u.getEmail().equals(UD.getUserList().get(i).getEmail())) {
+                Log.d("Backend Stub", "User exists.");
+                return true;
+            }
+        }
+        Log.d("Backend Stub", "User not exist.");
+        return false;
+    }
+
+    //Precondition: Check Exist before using.
+    public boolean verifyUser(User u) {
+
+        for (int i = 0; i < UD.getUserList().size(); i++) {
+            if (u.getEmail().equals(UD.getUserList().get(i).getEmail())) {
+                if (u.getPassword().equals(UD.getUserList().get(i).getPassword())) {
                     Log.d("Backend Stub", "Log in Successful.");
                     return true;
                 }

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Backend/BackendStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Backend/BackendStub.java
@@ -1,18 +1,38 @@
 package com.x7.ssad.ticketsystem.Backend;
 
+import android.app.Application;
+import android.content.Context;
+import android.util.DebugUtils;
 import android.util.Log;
 
+import com.google.gson.Gson;
+import com.x7.ssad.ticketsystem.Backend.Services.LoginService;
+import com.x7.ssad.ticketsystem.Backend.Services.MovieService;
 import com.x7.ssad.ticketsystem.Cache.CinemaCacheStub;
 import com.x7.ssad.ticketsystem.Cache.MovieCacheStub;
 import com.x7.ssad.ticketsystem.Cache.UserDAOStub;
 import com.x7.ssad.ticketsystem.Model.Cinema;
 import com.x7.ssad.ticketsystem.Model.Movie;
 import com.x7.ssad.ticketsystem.Model.User;
+import com.x7.ssad.ticketsystem.Utils.AddCookiesInterceptor;
+import com.x7.ssad.ticketsystem.Utils.ReceivedCookiesInterceptor;
 
+import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.prefs.Preferences;
 
+import okhttp3.Interceptor;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.ResponseBody;
+import okhttp3.logging.HttpLoggingInterceptor;
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
 import retrofit2.Retrofit;
+import retrofit2.converter.gson.GsonConverterFactory;
 
 /**
  * Created by WangYinghao on 5/26/17.
@@ -21,26 +41,20 @@ import retrofit2.Retrofit;
 //TODO: Change this to a real backend communication system.
 public class BackendStub {
 
+    public static final String BACKEND_SERVER_URI = "http://192.168.1.236:8081";
 
     private static BackendStub ourInstance = new BackendStub();
-    List<String> USERS;
-    List<String> PASSWORDS;
 
-    UserDAOStub UD;
     CinemaCacheStub CCS;
     MovieCacheStub MCS;
 
-    Retrofit retrofit;
+    LoginService loginService;
+    MovieService movieService;
 
     private BackendStub() {
-        USERS = new ArrayList<>();
-        PASSWORDS = new ArrayList<>();
 
-        UD = new UserDAOStub();
         CCS = new CinemaCacheStub();
         MCS = new MovieCacheStub();
-
-        retrofit = new Retrofit.Builder().baseUrl("http://localhost:8081").build();
 
     }
 
@@ -48,96 +62,59 @@ public class BackendStub {
         return ourInstance;
     }
 
-    //Precondition: Check Duplicate Before Using.
-    public boolean addUser(String username, String password) {
+    public void init(Application c) {
 
-        USERS.add(username);
-        PASSWORDS.add(password);
+        HttpLoggingInterceptor hli = new HttpLoggingInterceptor();
+        hli.setLevel(HttpLoggingInterceptor.Level.BODY);
 
-        Log.d("Backend Stub", "User Added");
-
-        return true;
+        OkHttpClient okHttpClient = new OkHttpClient.Builder()
+                .addInterceptor(new AddCookiesInterceptor(c))
+                .addInterceptor(new ReceivedCookiesInterceptor(c))
+                .addInterceptor(hli)
+                .build();
+        Retrofit retrofit = new Retrofit.Builder().baseUrl(BACKEND_SERVER_URI).callFactory(okHttpClient).addConverterFactory(GsonConverterFactory.create()).build();
+        loginService = retrofit.create(LoginService.class);
+        movieService = retrofit.create(MovieService.class);
 
     }
 
-    public boolean userExists(String username) {
-        for (int i = 0; i < USERS.size(); i++) {
-            if (username.equals(USERS.get(i))) {
-                Log.d("Backend Stub", "User exists.");
-                return true;
+    public int login(User u) {
+
+        Call<ResponseBody> loginCall = loginService.login(u);
+
+        try {
+            switch (loginCall.execute().code()) {
+                //User not exists
+                case 200:
+                    Log.d("Backend::Login", "Login Success");
+                    return 200;
+                //User exists
+                case 201:
+                    Log.d("Backend::Login", "User Created");
+                    return 201;
+                case 202:
+                    Log.d("Backend::Login", "User already logged in");
+                    return 202;
+                case 400:
+                    Log.d("Backend::Login", "Wrong Password");
+                    return 400;
+                default:
+                    Log.d("Backend::Login", "Unknown return code");
+                    return 404;
             }
+
         }
-        Log.d("Backend Stub", "User not exist.");
-        return false;
-    }
-
-    //Precondition: Check Exist before using.
-    public boolean verifyUser(String username, String password) {
-
-        for (int i = 0; i < USERS.size(); i++) {
-            if (username.equals(USERS.get(i))) {
-                if (password.equals(PASSWORDS.get(i))) {
-                    Log.d("Backend Stub", "Log in Successful.");
-                    return true;
-                }
-                else {
-                    Log.d("Backend Stub", "Password Incorrect.");
-                    return false;
-                }
-            }
-        }
-
-        Log.d("Backend Stub", "Unknown Error.");
-        return false;
-
-    }
-
-    //Precondition: Check Duplicate Before Using.
-    public boolean addUser(User u) {
-
-        UD.getUserList().add(u);
-
-        Log.d("Backend Stub", "User Added");
-
-        return true;
-
-    }
-
-    public boolean userExists(User u) {
-
-        for (int i = 0; i < UD.getUserList().size(); i++) {
-            if (u.getEmail().equals(UD.getUserList().get(i).getEmail())) {
-                Log.d("Backend Stub", "User exists.");
-                return true;
-            }
-        }
-        Log.d("Backend Stub", "User not exist.");
-        return false;
-    }
-
-    //Precondition: Check Exist before using.
-    public boolean verifyUser(User u) {
-
-        for (int i = 0; i < UD.getUserList().size(); i++) {
-            if (u.getEmail().equals(UD.getUserList().get(i).getEmail())) {
-                if (u.getPassword().equals(UD.getUserList().get(i).getPassword())) {
-                    Log.d("Backend Stub", "Log in Successful.");
-                    return true;
-                }
-                else {
-                    Log.d("Backend Stub", "Password Incorrect.");
-                    return false;
-                }
-            }
+        catch (Exception e) {
+            e.printStackTrace();
         }
 
-        Log.d("Backend Stub", "Unknown Error.");
-        return false;
+        Log.d("Backend::Login", "Unknown error");
+        return 500;
 
     }
 
     public List<Movie> getHotOnAirMovies() {
-        return MCS.getMovieList();
+        return MCS.getMovieList(movieService);
     }
 
     public List<Cinema> getCinemaList() {

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Backend/Services/LoginService.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Backend/Services/LoginService.java
@@ -1,0 +1,24 @@
+package com.x7.ssad.ticketsystem.Backend.Services;
+
+import com.x7.ssad.ticketsystem.Model.User;
+
+import okhttp3.ResponseBody;
+import retrofit2.Call;
+import retrofit2.http.Body;
+import retrofit2.http.GET;
+import retrofit2.http.POST;
+import retrofit2.http.Path;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public interface LoginService {
+
+    @POST("login")
+    Call<ResponseBody> login(@Body User user);
+
+    @GET("login/exists/{email}")
+    Call<ResponseBody> checkExists(@Path("email") String email);
+
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Backend/Services/MovieService.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Backend/Services/MovieService.java
@@ -1,0 +1,24 @@
+package com.x7.ssad.ticketsystem.Backend.Services;
+
+import com.x7.ssad.ticketsystem.Model.Movie;
+
+import java.util.List;
+
+import retrofit2.Call;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public interface MovieService {
+
+    //Only Movie IDs are returned.
+    @GET("/movie/air")
+    Call<List<Movie>> getAirMovies();
+
+    @GET("/movie/id/{id}")
+    Call<Movie> getMovieByID(@Path("id") String id);
+
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
@@ -188,7 +188,17 @@ public class MovieCacheStub {
 
     }
 
-    public Movie getMovie(int mid) { return hotMovies.get(mid - 1); }
+    public Movie getMovie(int mid) {
+        Movie movie = null;
+        for(Movie m : hotMovies) {
+            if (m.mid == mid) {
+                movie = m;
+            }
+        }
+
+        assert movie != null;
+        return movie;
+    }
 
     public List<Movie> getMovieList() {
         return hotMovies;
@@ -205,6 +215,9 @@ public class MovieCacheStub {
 
             for(Movie m : airingMovies) {
 
+                //TODO: Load Image with Universal Image Loader
+                m.imageid = R.mipmap.poster_stub;
+                //TODO: Use real data
                 m.staffList = staffList;
                 m.movieshotIdList = movieshotIdList;
                 m.boxOffice = tmpBoxOffice;

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
@@ -26,8 +26,8 @@ import retrofit2.Call;
 public class MovieCacheStub {
 
     //TODO: replace public member movie_list(local fake data) with hotMovies(actual network data)
-    List<Movie> movie_list;
-    List<Movie> hotMovies;
+    List<Movie> movie_list; //Fake Data
+    List<Movie> hotMovies;  //Real Internet Data
 
     List<StaffInfo> staffList;
     int movieshotIdList[] = {R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot};
@@ -188,20 +188,10 @@ public class MovieCacheStub {
 
     }
 
-    public Movie getMovie(int mid) {
-
-        Movie movie = null;
-        for (Movie m : hotMovies) {
-            if (m.mid == mid)
-                movie = m;
-        }
-
-        assert movie != null;
-        return movie;
-    }
+    public Movie getMovie(int mid) { return hotMovies.get(mid - 1); }
 
     public List<Movie> getMovieList() {
-        return movie_list;
+        return hotMovies;
     }
 
     public List<Movie> getMovieList(MovieService movieService) {

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Cache/MovieCacheStub.java
@@ -2,6 +2,7 @@ package com.x7.ssad.ticketsystem.Cache;
 
 import android.util.Log;
 
+import com.x7.ssad.ticketsystem.Backend.Services.MovieService;
 import com.x7.ssad.ticketsystem.Model.BoxOffice;
 import com.x7.ssad.ticketsystem.Model.Cinema;
 import com.x7.ssad.ticketsystem.Model.Movie;
@@ -15,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
+import retrofit2.Call;
+
 /**
  * Created by WangYinghao on 5/26/17.
  */
@@ -22,7 +25,14 @@ import java.util.List;
 //TODO: implement a real movie cache system
 public class MovieCacheStub {
 
+    //TODO: replace public member movie_list(local fake data) with hotMovies(actual network data)
     List<Movie> movie_list;
+    List<Movie> hotMovies;
+
+    List<StaffInfo> staffList;
+    int movieshotIdList[] = {R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot};
+    BoxOffice tmpBoxOffice;
+    List<MovieComment> commentList;
 
     public MovieCacheStub() {
 
@@ -32,19 +42,16 @@ public class MovieCacheStub {
         try {
 
             //temp data
-            List<StaffInfo> staffList = new ArrayList<>();
+            staffList = new ArrayList<>();
             for (int i = 0; i < 6; i++) {
                 StaffInfo myStaffInfo = new StaffInfo(R.mipmap.johnny_depp,
                         "约翰尼·德普133", "饰 杰克船长333333");
                 staffList.add(myStaffInfo);
             }
 
-            int movieshotIdList[] = {R.mipmap.movie_shot, R.mipmap.movie_shot,
-                    R.mipmap.movie_shot, R.mipmap.movie_shot, R.mipmap.movie_shot};
+            tmpBoxOffice = new BoxOffice(2, 8663, 93546);
 
-            BoxOffice tmpBoxOffice = new BoxOffice(2, 8663, 93546);
-
-            List<MovieComment> commentList = new ArrayList<>();
+            commentList = new ArrayList<>();
             for (int i = 0; i < 7; i++) {
                 MovieComment movieComment = new MovieComment(R.mipmap.ic_launcher,
                         "吃过群众" + i, "饰 饰 杰克船长333333aaaaaaaaaaa啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊啊凄凄切切群群群群群群群群群群群群群", "05-06");
@@ -182,10 +189,45 @@ public class MovieCacheStub {
     }
 
     public Movie getMovie(int mid) {
-        return movie_list.get(mid - 1);
+
+        Movie movie = null;
+        for (Movie m : hotMovies) {
+            if (m.mid == mid)
+                movie = m;
+        }
+
+        assert movie != null;
+        return movie;
     }
 
     public List<Movie> getMovieList() {
         return movie_list;
+    }
+
+    public List<Movie> getMovieList(MovieService movieService) {
+
+        hotMovies = new ArrayList<>();
+
+        Call<List<Movie>> getAirMovieIDCALL = movieService.getAirMovies();
+
+        try {
+            List<Movie> airingMovies = getAirMovieIDCALL.execute().body();
+
+            for(Movie m : airingMovies) {
+
+                m.staffList = staffList;
+                m.movieshotIdList = movieshotIdList;
+                m.boxOffice = tmpBoxOffice;
+                m.commentList = commentList;
+
+                hotMovies.add(m);
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        return hotMovies;
+
     }
 }

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Cache/PreferenceDAO.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Cache/PreferenceDAO.java
@@ -1,0 +1,52 @@
+package com.x7.ssad.ticketsystem.Cache;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.SharedPreferences;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public class PreferenceDAO {
+
+    private static PreferenceDAO instance;
+
+    public static PreferenceDAO get() {
+        if (instance == null) instance = getSync();
+        return instance;
+    }
+
+    private static synchronized PreferenceDAO getSync() {
+        if (instance == null) instance = new PreferenceDAO();
+        return instance;
+    }
+
+    private PreferenceDAO() {
+    }
+
+    public void init(Application a) {
+        preferences = a.getSharedPreferences("TicketSystem", Context.MODE_PRIVATE);
+        editor = preferences.edit();
+
+    }
+
+    SharedPreferences preferences;
+    SharedPreferences.Editor editor;
+
+    public Set<String> getCookieSets(HashSet<String> cookies) {
+
+        return preferences.getStringSet("COOKIES", cookies);
+
+    }
+
+    public void putCookieSets(HashSet<String> cookies) {
+
+        editor.putStringSet("COOKIES", cookies);
+        editor.commit();
+
+    }
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Cache/UserDAOStub.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Cache/UserDAOStub.java
@@ -1,0 +1,23 @@
+package com.x7.ssad.ticketsystem.Cache;
+
+import com.x7.ssad.ticketsystem.Model.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public class UserDAOStub {
+
+    List<User> userList = new ArrayList<>();
+
+    public List<User> getUserList() {
+        return userList;
+    }
+
+    public void setUserList(List<User> userList) {
+        this.userList = userList;
+    }
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Fragments/MovieFragment.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Fragments/MovieFragment.java
@@ -24,6 +24,8 @@ import com.x7.ssad.ticketsystem.Model.User;
 import com.x7.ssad.ticketsystem.R;
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -86,6 +88,7 @@ public class MovieFragment extends Fragment {
                 return null;
             }
 
+            Collections.sort(movieRetrieved, new MovieRatingComparator());
             return movieRetrieved;
 
         }
@@ -101,6 +104,13 @@ public class MovieFragment extends Fragment {
 
         @Override
         protected void onCancelled() {
+        }
+
+        private class MovieRatingComparator implements Comparator<Movie> {
+            @Override
+            public int compare(Movie movie, Movie t1) {
+                return (int)Math.signum(t1.audience_rating - movie.audience_rating);
+            }
         }
     }
 

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Fragments/MovieFragment.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Fragments/MovieFragment.java
@@ -1,6 +1,9 @@
 package com.x7.ssad.ticketsystem.Fragments;
 
 
+import android.app.Activity;
+import android.content.Intent;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -11,16 +14,28 @@ import android.os.Bundle;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.util.Log;
+import android.widget.Toast;
 
+import com.x7.ssad.ticketsystem.Activities.MainActivity;
 import com.x7.ssad.ticketsystem.Adapters.HotOnAirMovieAdapter;
 import com.x7.ssad.ticketsystem.Backend.BackendStub;
 import com.x7.ssad.ticketsystem.Model.Movie;
+import com.x7.ssad.ticketsystem.Model.User;
 import com.x7.ssad.ticketsystem.R;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * A simple {@link Fragment} subclass.
  */
 public class MovieFragment extends Fragment {
+
+    private List<Movie> movies;
+    HotOnAirMovieAdapter movieAdapter;
+
+    private GetMovietask getMovietask;
+
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
@@ -34,9 +49,64 @@ public class MovieFragment extends Fragment {
         mLLM.setOrientation(LinearLayoutManager.VERTICAL);
         HotOnAirMovieList.setLayoutManager(mLLM);
 
-        Log.d("Activity", Integer.toString(backend.getHotOnAirMovies().size()));
+        movies = new ArrayList<>();
+        movieAdapter = new HotOnAirMovieAdapter(getActivity(), movies);
+        HotOnAirMovieList.setAdapter(movieAdapter);
 
-        HotOnAirMovieList.setAdapter(new HotOnAirMovieAdapter(getActivity(), backend));
+        getMovietask = new GetMovietask(getActivity());
+        getMovietask.execute((Void) null);
+
         return rootView;
     }
+
+    /**
+     * Asynchronous task to retrieve movie list.
+     */
+    public class GetMovietask extends AsyncTask<Void, Void, List> {
+
+        Activity _a;
+        BackendStub mBackend;
+
+
+        GetMovietask(Activity a) {
+            _a = a;
+            mBackend = BackendStub.getInstance();
+        }
+
+        @Override
+        protected List doInBackground(Void... params) {
+            // TODO: attempt authentication against a network service.
+
+            List<Movie> movieRetrieved;
+            try {
+                // Simulate network access.
+                movieRetrieved = mBackend.getHotOnAirMovies();
+            } catch (Exception e) {
+                e.printStackTrace();
+                return null;
+            }
+
+            return movieRetrieved;
+
+        }
+
+        @Override
+        protected void onPostExecute(final List movieRetrieved) {
+            if (movieRetrieved != null) {
+                movies.addAll(movieRetrieved);
+                movieAdapter.notifyDataSetChanged();
+            }
+
+        }
+
+        @Override
+        protected void onCancelled() {
+        }
+    }
+
 }
+
+
+
+
+

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Model/Cinema.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Model/Cinema.java
@@ -1,5 +1,6 @@
 package com.x7.ssad.ticketsystem.Model;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -26,5 +27,19 @@ public class Cinema {
         this.cName = name;
         this.cPosition = position;
         this.cLowestPrice = price;
+    }
+
+    @Override
+    public String toString() {
+        return "Cinema{" +
+                "cid=" + cid +
+                ", cName='" + cName + '\'' +
+                ", ShowingMovie=" + Arrays.toString(ShowingMovie) +
+                ", ShowingCnt=" + Arrays.toString(ShowingCnt) +
+                ", cPosition='" + cPosition + '\'' +
+                ", cLowestPrice=" + cLowestPrice +
+                ", cScore=" + cScore +
+                ", cTicketList=" + cTicketList +
+                '}';
     }
 }

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
@@ -23,6 +23,9 @@ public class Movie {
     public String movieIntro;
 
     public int imageid;
+    public String smallImageURI;
+    public String mediumImageURI;
+    public String largeImageURI;
 
     public List<StaffInfo> staffList;  //主创人员列表
     public int[] movieshotIdList;      //电影剪影列表

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class Movie {
 
     public int mid;
+    public int douid;                 //豆瓣电影id
     public String name;
     public String nameEng;
     public float audience_rating;     //观众评分

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Model/Movie.java
@@ -18,6 +18,7 @@ public class Movie {
     public String movieSourceDest;    //电影制作地
     public int movieLength;           //按分钟算
     public int nWantSee;
+    public String oneSentence;
     public String movieIntro;
 
     public int imageid;

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Model/User.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Model/User.java
@@ -1,0 +1,40 @@
+package com.x7.ssad.ticketsystem.Model;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public class User  {
+
+    String email;
+    String password;
+
+    public User(String e, String p) {
+        email = e;
+        password = p;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+                "email='" + email + '\'' +
+                ", password='" + password + '\'' +
+                '}';
+    }
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Session/SessionManager.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Session/SessionManager.java
@@ -2,6 +2,8 @@ package com.x7.ssad.ticketsystem.Session;
 
 import android.util.Pair;
 
+import com.x7.ssad.ticketsystem.Model.User;
+
 import java.util.ArrayList;
 
 /**
@@ -19,7 +21,7 @@ public class SessionManager {
         selectSeats = new ArrayList<>();
     }
 
-    private String myEmail;
+    private User myUser;
     private int myMovieID = -1;
     private boolean isOnAir;
     private Long myCinemaID;
@@ -28,12 +30,13 @@ public class SessionManager {
     private ArrayList<Pair<Integer, Integer>> selectSeats;
 
     //Tips: 按Ctrl+N 可自动生成getter&setter.
-    public String getMyEmail() {
-        return myEmail;
+
+    public User getMyUser() {
+        return myUser;
     }
 
-    public void setMyEmail(String myEmail) {
-        this.myEmail = myEmail;
+    public void setMyUser(User myUser) {
+        this.myUser = myUser;
     }
 
     public int getMyMovieID() {

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Utils/AddCookiesInterceptor.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Utils/AddCookiesInterceptor.java
@@ -1,0 +1,47 @@
+package com.x7.ssad.ticketsystem.Utils;
+
+import android.app.Application;
+import android.content.Context;
+import android.util.Log;
+
+import com.x7.ssad.ticketsystem.Cache.PreferenceDAO;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import okhttp3.Interceptor;
+import okhttp3.Request;
+import okhttp3.Response;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public class AddCookiesInterceptor implements Interceptor {
+
+    PreferenceDAO Preferences;
+
+    public AddCookiesInterceptor(Application a) {
+        Preferences = PreferenceDAO.get();
+        Preferences.init(a);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+
+        Request.Builder builder = chain.request().newBuilder();
+        //TODO: retrieve cookies from local preferences
+        HashSet<String> preferences = (HashSet<String>) Preferences.getCookieSets(new HashSet<String>());
+
+        for (String cookie : preferences) {
+
+            builder.addHeader("Cookie", cookie);
+            Log.v("OkHttp", "Adding Header: " + cookie);
+
+        }
+
+        return chain.proceed(builder.build());
+
+    }
+
+}

--- a/app/src/main/java/com/x7/ssad/ticketsystem/Utils/ReceivedCookiesInterceptor.java
+++ b/app/src/main/java/com/x7/ssad/ticketsystem/Utils/ReceivedCookiesInterceptor.java
@@ -1,0 +1,49 @@
+package com.x7.ssad.ticketsystem.Utils;
+
+import android.app.Application;
+import android.content.Context;
+
+import com.x7.ssad.ticketsystem.Cache.PreferenceDAO;
+
+import java.io.IOException;
+import java.util.HashSet;
+
+import okhttp3.Interceptor;
+import okhttp3.Response;
+
+/**
+ * Created by WangYinghao on 6/8/17.
+ */
+
+public class ReceivedCookiesInterceptor implements Interceptor {
+
+    PreferenceDAO Preferences;
+
+    public ReceivedCookiesInterceptor(Application a) {
+        Preferences = PreferenceDAO.get();
+        Preferences.init(a);
+    }
+
+    @Override
+    public Response intercept(Chain chain) throws IOException {
+
+        Response originalResponse = chain.proceed(chain.request());
+
+        if (!originalResponse.headers("Set-Cookie").isEmpty()) {
+
+            HashSet<String> cookies = new HashSet<>();
+
+            for (String header : originalResponse.headers("Set-Cookie")) {
+                cookies.add(header);
+            }
+
+            //TODO: persist all cookies into local preferences
+            Preferences.putCookieSets(cookies);
+
+        }
+
+        return originalResponse;
+
+    }
+
+}

--- a/app/src/main/res/layout/activity_check_permission.xml
+++ b/app/src/main/res/layout/activity_check_permission.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="com.x7.ssad.ticketsystem.Activities.CheckPermissionActivity">
+
+</android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/item_hot_on_air_movie.xml
+++ b/app/src/main/res/layout/item_hot_on_air_movie.xml
@@ -8,7 +8,7 @@
         android:id="@+id/hot_on_air_movie_poster_view"
         android:layout_width="60dp"
         android:layout_height="80dp"
-        android:scaleType="centerInside"
+        android:scaleType="fitXY"
         android:src="@mipmap/poster_stub"/>
 
     <LinearLayout


### PR DESCRIPTION
注意：本版本需要使用我写的Node.js后台才能正常运行。建议下次会议之前不要Merge，或者Merge到新Branch中。

ChangeLog:
1. 用户登录实现前后端对接
1.1 所有HTTP请求均会被自动打上Cookie
1.2 尚未实现前端会话管理，建议TODO: 在前端保存Session LifeTime，过期要求用户重新登录
2. 电影列表抓取实现从后台获取数据
2.1 数据来源为豆瓣Api v2 基本版，有部分数据缺失，仍用本地数据填充
2.2 电影列表没有本地持久化
3. Minor Bug Fix & Merge to #16 ，确保主流程能成功完成。

TechLog:
1. 前后端交互依赖[Retrofit](https://github.com/square/retrofit)
1.1 Retrofit Interceptor 实现自动Cookie戳
2. [Universal Image Loader](https://github.com/nostra13/Android-Universal-Image-Loader)实现远程图片抓取并缓存 **神器，建议去看看**
3. [RxPermission](https://github.com/tbruyelle/RxPermissions) 实现权限管理
4. Jack编译器与Java 8... 主要是为了支持RxPermission的Lambda用法，我已经向作者[询问](https://github.com/tbruyelle/RxPermissions/issues/151)不使用Lambda的方法，一旦知道就去掉。

用户登录返回代码

|Code|Meaning|
|---|---|
|200|Login Success|
|201|User Created|
|202|Already Logged In|
|400|Wrong Password|